### PR TITLE
Injector.get now infers instance type from constructor

### DIFF
--- a/di.d.ts
+++ b/di.d.ts
@@ -9,9 +9,7 @@ declare module di {
     constructor();
     constructor(locals: any[]);
     constructor(locals: any[], parent: Injector);
-    //can anybody solve this?? :)
-    //get<T, U extends IClassInterface<any>>(classFunc: U): T; //todo IClassInterface<T>
-    get(classFunc: any): any; //todo IClassInterface<T>
+    get(classFunc: IClassInterface<T>): T;
   }
 
 }


### PR DESCRIPTION
I haven't tested this change in context, but I've used this type pattern elsewhere:

buff.ly/1DowGV2 

```
create<T>(fromClass: Constructor<T>): T {

interface Constructor<T> {
    new (...a): T;
}
```
