### PR TITLE
Fix for only one dependency can be used for a class

### DIFF
--- a/di.d.ts
+++ b/di.d.ts
@@ -13,7 +13,7 @@ declare module di {
   }
 
   export class Inject {
-    constructor(injectableClass: IClassInterface<any>);
+    constructor(...injectableClasses: Array<IClassInterface<any>>);
   }
 
   export class Provide {

--- a/index.js
+++ b/index.js
@@ -3,10 +3,16 @@
 require('reflect-metadata');
 var di = require('di');
 exports.Injector = di.Injector;
+function factory(data) {
+    function F() {
+        di.Inject.apply(this, data);
+    }
+    F.prototype = di.Inject.prototype;
+    return new F();
+}
 function Inject(classFunc) {
     var dependencies = Reflect.getMetadata("design:paramtypes", classFunc) || [];
-    var annotateArgs = [classFunc].concat(dependencies.map(function (dep) { return new di.Inject(dep); }));
-    di.annotate.apply(di, annotateArgs);
+    di.annotate(classFunc, factory(dependencies));
 }
 exports.Inject = Inject;
 function Provide(targetClassFunc) {

--- a/index.ts
+++ b/index.ts
@@ -5,13 +5,19 @@
 import 'reflect-metadata';
 import * as di from 'di'
 
-
 export var Injector = di.Injector;
+
+function factory(data: Array<any>) : di.Inject {
+  function F() : void {
+    di.Inject.apply(this, data);
+  }
+  F.prototype = di.Inject.prototype;
+  return new F();
+}
 
 export function Inject(classFunc: any) {
   const dependencies = Reflect.getMetadata("design:paramtypes", classFunc) || [];
-  var annotateArgs = [classFunc].concat(dependencies.map((dep: any) => new di.Inject(dep)));
-  di.annotate.apply(di, annotateArgs);
+  di.annotate(classFunc, factory(dependencies));
 }
 
 export function Provide(targetClassFunc: any) {

--- a/spec/fixtures.ts
+++ b/spec/fixtures.ts
@@ -9,9 +9,14 @@ export class Engine {
 
 }
 
+export class Doors {
+
+}
+
+
 @Inject
 export class Car {
-  constructor(public engine: Engine) {}
+  constructor(public engine: Engine, public doors:Doors) {}
 }
 
 @Provide(Engine)

--- a/spec/main.ts
+++ b/spec/main.ts
@@ -1,7 +1,6 @@
 /// <reference path="../typings/mocha/mocha.d.ts"/>
-/// <reference path="./typings/expectations.d.ts"/>
+/// <reference path="../typings/expectations/expectations.d.ts"/>
 import 'expectations'
-
 
 import {Injector} from '../index'
 import {Engine, MockEngine, Car} from './fixtures'

--- a/spec/main.ts
+++ b/spec/main.ts
@@ -3,7 +3,7 @@
 import 'expectations'
 
 import {Injector} from '../index'
-import {Engine, MockEngine, Car} from './fixtures'
+import {Engine, MockEngine, Car, Doors} from './fixtures'
 
 describe("di.ts", () => {
 
@@ -14,7 +14,7 @@ describe("di.ts", () => {
     expect(engine instanceof Engine).toBeTruthy();
   });
 
-  it("should instatiate a class with dependency", () => {
+  it("should instantiate a class with dependency", () => {
     var injector = new Injector();
     var car: Car = injector.get(Car);
 
@@ -22,7 +22,18 @@ describe("di.ts", () => {
     expect(car.engine instanceof Engine).toBeTruthy();
   });
 
-  it("should instatiate a class with mocked dependency", () => {
+  it("should instantiate a class with multiple dependencies", () => {
+
+    var injector = new Injector();
+    var car: Car = injector.get(Car);
+
+    expect(car instanceof Car).toBeTruthy();
+    expect(car.engine instanceof Engine).toBeTruthy();
+    expect(car.doors instanceof Doors).toBeTruthy();
+
+  });
+
+  it("should instantiate a class with mocked dependency", () => {
     var injector = new Injector([MockEngine]);
     var car: Car = injector.get(Car);
 

--- a/tsd.json
+++ b/tsd.json
@@ -10,6 +10,9 @@
     },
     "mocha/mocha.d.ts": {
       "commit": "52fa2b9ce36f2c5843204e9bfbaada7cded9b47a"
+    },
+    "expectations/expectations.d.ts": {
+      "commit": "c7b1128cc9a8f5797bade826e7632b36b06a856c"
     }
   }
 }


### PR DESCRIPTION
Hi, 

Great library, I noticed an issue where only one dependency can be used for a class, due to some code in index.ts.

I've gone ahead and fixed the issue here, with a unit test to prove the problem.

I've also added 'expectations' as TSD dep as I could not get your repo working without it.

Thanks!

-Eddy
